### PR TITLE
Add Zustand store, React Query provider and UI tweaks

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 
 import { useState, useCallback } from "react"
+import dynamic from "next/dynamic"
 import { motion } from "framer-motion"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -52,7 +53,10 @@ import { SeasonEventSystem } from "@/components/season-event-system"
 import { InjurySystem } from "@/components/injury-system"
 import { PersonalitySystem } from "@/components/personality-system"
 import { RivalSystem } from "@/components/rival-system"
-import { GrowthAnalysis } from "@/components/growth-analysis"
+const GrowthAnalysis = dynamic(() => import("@/components/growth-analysis"), {
+  ssr: false,
+})
+import { useGameUIStore } from "@/lib/store"
 import { GameMenu } from "@/components/ui/game-menu"
 import { NotificationSystem, type Notification } from "@/components/ui/notification-system"
 import { GameHud } from "@/components/ui/game-hud"
@@ -384,7 +388,9 @@ const WEEKLY_TEMPLATES = {
 }
 
 export default function StreetDreamsSoccer() {
-  const [notifications, setNotifications] = useState<Notification[]>([])
+  const notifications = useGameUIStore((s) => s.notifications)
+  const addStoreNotification = useGameUIStore((s) => s.addNotification)
+  const removeStoreNotification = useGameUIStore((s) => s.removeNotification)
 
   // 게임 상태 (확장됨)
   const [gameState, setGameState] = useState<GameState>({
@@ -609,12 +615,18 @@ export default function StreetDreamsSoccer() {
     ],
   })
 
-  const [activeTab, setActiveTab] = useState("dashboard")
-  const [monthlyResult, setMonthlyResult] = useState<any>(null)
-  const [selectedDay, setSelectedDay] = useState<number | null>(null)
-  const [currentActivity, setCurrentActivity] = useState<string | null>(null)
-  const [dayEvents, setDayEvents] = useState<React.ReactNode[]>([])
-  const [selectedTemplate, setSelectedTemplate] = useState<string>("street_warrior")
+  const activeTab = useGameUIStore((s) => s.activeTab)
+  const setActiveTab = useGameUIStore((s) => s.setActiveTab)
+  const monthlyResult = useGameUIStore((s) => s.monthlyResult)
+  const setMonthlyResult = useGameUIStore((s) => s.setMonthlyResult)
+  const selectedDay = useGameUIStore((s) => s.selectedDay)
+  const setSelectedDay = useGameUIStore((s) => s.setSelectedDay)
+  const currentActivity = useGameUIStore((s) => s.currentActivity)
+  const setCurrentActivity = useGameUIStore((s) => s.setCurrentActivity)
+  const dayEvents = useGameUIStore((s) => s.dayEvents)
+  const setDayEvents = useGameUIStore((s) => s.setDayEvents)
+  const selectedTemplate = useGameUIStore((s) => s.selectedTemplate)
+  const setSelectedTemplate = useGameUIStore((s) => s.setSelectedTemplate)
 
   // 활동 목록 (기존과 동일)
   const activities: Activity[] = [
@@ -843,14 +855,17 @@ export default function StreetDreamsSoccer() {
         icon,
         duration: type === "achievement" ? 6000 : 4000,
       }
-      setNotifications((prev) => [...prev, newNotification])
+      addStoreNotification(newNotification)
     },
-    [],
+    [addStoreNotification],
   )
 
-  const removeNotification = useCallback((id: string) => {
-    setNotifications((prev) => prev.filter((n) => n.id !== id))
-  }, [])
+  const removeNotification = useCallback(
+    (id: string) => {
+      removeStoreNotification(id)
+    },
+    [removeStoreNotification],
+  )
 
   const handleSave = useCallback(() => {
     try {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,10 +4,12 @@ import type React from "react"
 
 import { ThemeProvider } from "next-themes"
 import { useState, useEffect } from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { SoundProvider } from "@/components/sound-context"
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [mounted, setMounted] = useState(false)
+  const [queryClient] = useState(() => new QueryClient())
 
   useEffect(() => {
     setMounted(true)
@@ -18,8 +20,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
-      <SoundProvider>{children}</SoundProvider>
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+        <SoundProvider>{children}</SoundProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
   )
 }

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,0 +1,40 @@
+import type React from "react"
+import { create } from "zustand"
+import type { Notification } from "@/components/ui/notification-system"
+
+interface GameUIStore {
+  notifications: Notification[]
+  activeTab: string
+  monthlyResult: any
+  selectedDay: number | null
+  currentActivity: string | null
+  dayEvents: React.ReactNode[]
+  selectedTemplate: string
+  addNotification: (n: Notification) => void
+  removeNotification: (id: string) => void
+  setActiveTab: (tab: string) => void
+  setMonthlyResult: (result: any) => void
+  setSelectedDay: (day: number | null) => void
+  setCurrentActivity: (activity: string | null) => void
+  setDayEvents: (events: React.ReactNode[]) => void
+  setSelectedTemplate: (template: string) => void
+}
+
+export const useGameUIStore = create<GameUIStore>((set) => ({
+  notifications: [],
+  activeTab: "dashboard",
+  monthlyResult: null,
+  selectedDay: null,
+  currentActivity: null,
+  dayEvents: [],
+  selectedTemplate: "street_warrior",
+  addNotification: (n) => set((s) => ({ notifications: [...s.notifications, n] })),
+  removeNotification: (id) =>
+    set((s) => ({ notifications: s.notifications.filter((n) => n.id !== id) })),
+  setActiveTab: (tab) => set({ activeTab: tab }),
+  setMonthlyResult: (result) => set({ monthlyResult: result }),
+  setSelectedDay: (day) => set({ selectedDay: day }),
+  setCurrentActivity: (activity) => set({ currentActivity: activity }),
+  setDayEvents: (events) => set({ dayEvents: events }),
+  setSelectedTemplate: (template) => set({ selectedTemplate: template }),
+}))

--- a/package.json
+++ b/package.json
@@ -61,7 +61,9 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "zustand": "^4.5.2",
+    "@tanstack/react-query": "^5.28.0"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,7 +20,7 @@ body {
     --card-foreground: 240 5% 10%;
     --popover: 240 5% 98%;
     --popover-foreground: 240 5% 10%;
-    --primary: 250 67% 54%;
+    --primary: 238 82% 60%;
     --primary-foreground: 0 0% 100%;
     --secondary: 240 6% 90%;
     --secondary-foreground: 240 5% 20%;
@@ -55,7 +55,7 @@ body {
     --card-foreground: 0 0% 98%;
     --popover: 240 5% 12%;
     --popover-foreground: 0 0% 98%;
-    --primary: 250 67% 54%;
+    --primary: 238 82% 60%;
     --primary-foreground: 0 0% 100%;
     --secondary: 240 5% 18%;
     --secondary-foreground: 0 0% 98%;


### PR DESCRIPTION
## Summary
- manage UI state with a new `useGameUIStore` using Zustand
- load GrowthAnalysis lazily with dynamic import
- add React Query to providers
- tweak primary color in global styles
- include required deps in `package.json`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a97aa80f48325bb3020de6cd27af9