### PR TITLE
Introduce FIFA-themed palette and fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,14 @@ The Firebase client is initialized in [`lib/firebase.ts`](lib/firebase.ts) and e
 The `arcade` tab showcases a lightweight Phaser demo built with Next.js. The new
 component is loaded dynamically and allows simple keyboard controls for a square
 avatar. Dependencies are managed via `pnpm` and include `phaser`.
+
+## FIFA Style Theme
+
+The app now ships with a darker FIFA-inspired palette and Google Fonts:
+
+- **Orbitron** for futuristic headings
+- **Russo One** for numeric displays
+- **Bebas Neue** for impactful titles
+- **Inter** as the default body font
+
+Player cards can use the classes `fifa-card-gold`, `fifa-card-diamond`, or `fifa-card-legend` for special backgrounds. Use the `bg-fifa-gradient` utility for the default dark gradient background.

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,20 +4,20 @@
 
 @layer base {
   :root {
-    --background: 240 5% 95%;
-    --foreground: 240 5% 10%;
-    --card: 240 5% 98%;
-    --card-foreground: 240 5% 10%;
-    --popover: 240 5% 98%;
-    --popover-foreground: 240 5% 10%;
-    --primary: 250 67% 54%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 240 6% 90%;
-    --secondary-foreground: 240 5% 20%;
-    --muted: 240 6% 90%;
-    --muted-foreground: 240 3% 40%;
-    --accent: 217 91% 60%;
-    --accent-foreground: 0 0% 100%;
+    --background: 0 0% 0%;
+    --foreground: 0 0% 100%;
+    --card: 240 5% 15%;
+    --card-foreground: 0 0% 100%;
+    --popover: 240 5% 15%;
+    --popover-foreground: 0 0% 100%;
+    --primary: 216 60% 10%;
+    --primary-foreground: 51 100% 50%;
+    --secondary: 190 100% 50%;
+    --secondary-foreground: 111 100% 54%;
+    --muted: 0 0% 20%;
+    --muted-foreground: 0 0% 80%;
+    --accent: 0 0% 75%;
+    --accent-foreground: 29 57% 46%;
     --destructive: 0 70% 50%;
     --destructive-foreground: 0 0% 100%;
     --border: 240 5% 80%;
@@ -29,33 +29,37 @@
     --chart-3: 196 100% 54%;
     --chart-4: 32 100% 61%;
     --chart-5: 340 75% 55%;
+    --gradient-start: 0 0% 0%;
+    --gradient-end: 240 28% 14%;
   }
 
   .dark {
-    --background: 240 5% 10%;
-    --foreground: 0 0% 98%;
-    --card: 240 5% 12%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 5% 12%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 250 67% 54%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 240 5% 18%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 5% 18%;
-    --muted-foreground: 240 2% 60%;
-    --accent: 217 91% 60%;
-    --accent-foreground: 0 0% 100%;
+    --background: 240 28% 14%;
+    --foreground: 0 0% 100%;
+    --card: 216 20% 20%;
+    --card-foreground: 0 0% 100%;
+    --popover: 216 20% 20%;
+    --popover-foreground: 0 0% 100%;
+    --primary: 216 60% 10%;
+    --primary-foreground: 51 100% 50%;
+    --secondary: 190 100% 50%;
+    --secondary-foreground: 111 100% 54%;
+    --muted: 0 0% 30%;
+    --muted-foreground: 0 0% 90%;
+    --accent: 0 0% 75%;
+    --accent-foreground: 29 57% 46%;
     --destructive: 0 70% 50%;
     --destructive-foreground: 0 0% 100%;
-    --border: 240 5% 25%;
-    --input: 240 5% 25%;
-    --ring: 250 67% 54%;
+    --border: 216 20% 30%;
+    --input: 216 20% 30%;
+    --ring: 51 100% 50%;
     --chart-1: 250 67% 54%;
     --chart-2: 217 91% 60%;
     --chart-3: 196 100% 54%;
     --chart-4: 32 100% 61%;
     --chart-5: 340 75% 55%;
+    --gradient-start: 0 0% 0%;
+    --gradient-end: 240 28% 14%;
   }
 }
 
@@ -80,6 +84,19 @@
 
 .font-russo {
   font-family: var(--font-russo);
+}
+
+.font-bebas {
+  font-family: var(--font-bebas);
+}
+
+/* FIFA 다크 그라데이션 배경 */
+.bg-fifa-gradient {
+  background-image: linear-gradient(
+    to bottom,
+    hsl(var(--gradient-start)),
+    hsl(var(--gradient-end))
+  );
 }
 
 /* 커스텀 애니메이션 */
@@ -584,4 +601,26 @@ textarea:focus {
     background: rgba(0, 0, 0, 0.8);
     border: 2px solid white;
   }
+}
+
+/* FIFA 스타일 카드 */
+.fifa-card-gold {
+  background: linear-gradient(135deg, #b87333, #ffd700);
+  border: 2px solid #ffd700;
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 10px rgba(255, 215, 0, 0.5);
+}
+
+.fifa-card-diamond {
+  background: linear-gradient(135deg, #e0f7ff, #b0e0e6);
+  border: 2px solid #00d4ff;
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 10px rgba(0, 212, 255, 0.5);
+}
+
+.fifa-card-legend {
+  background: linear-gradient(135deg, #ffffff, #e0e0e0);
+  border: 2px solid #ffd700;
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 12px rgba(255, 215, 0, 0.7);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,17 @@
 import type React from "react"
 import type { Metadata } from "next"
-import { Inter } from "next/font/google"
+import {
+  Inter,
+  Orbitron,
+  Russo_One,
+  Bebas_Neue,
+} from "next/font/google"
 import "./globals.css"
 
-const inter = Inter({ subsets: ["latin"] })
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" })
+const orbitron = Orbitron({ subsets: ["latin"], variable: "--font-orbitron" })
+const russo = Russo_One({ subsets: ["latin"], variable: "--font-russo" })
+const bebas = Bebas_Neue({ subsets: ["latin"], variable: "--font-bebas" })
 
 export const metadata: Metadata = {
   title: "Street Dreams: European Journey",
@@ -17,8 +25,8 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="ko">
-      <body className={inter.className}>{children}</body>
+    <html lang="ko" className={`${inter.variable} ${orbitron.variable} ${russo.variable} ${bebas.variable}`}> 
+      <body className="font-inter">{children}</body>
     </html>
   )
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,10 +9,16 @@ const config: Config = {
     "*.{js,ts,jsx,tsx,mdx}"
   ],
   theme: {
-  	extend: {
-  		colors: {
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
+        extend: {
+                fontFamily: {
+                        sans: ['var(--font-inter)', 'sans-serif'],
+                        orbitron: ['var(--font-orbitron)', 'sans-serif'],
+                        russo: ['var(--font-russo)', 'sans-serif'],
+                        bebas: ['var(--font-bebas)', 'sans-serif'],
+                },
+                colors: {
+                        background: 'hsl(var(--background))',
+                        foreground: 'hsl(var(--foreground))',
   			card: {
   				DEFAULT: 'hsl(var(--card))',
   				foreground: 'hsl(var(--card-foreground))'


### PR DESCRIPTION
## Summary
- integrate FIFA fonts via `next/font`
- update color tokens for a darker FIFA palette
- add utility classes for FIFA card designs
- expose additional font classes and gradient utilities

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684abdce47d083259842be1d0d431793