### PR TITLE
Fix Bebas Neue font weight

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,11 @@ import "./globals.css"
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" })
 const orbitron = Orbitron({ subsets: ["latin"], variable: "--font-orbitron" })
 const russo = Russo_One({ subsets: ["latin"], variable: "--font-russo" })
-const bebas = Bebas_Neue({ subsets: ["latin"], variable: "--font-bebas" })
+const bebas = Bebas_Neue({
+  weight: "400",
+  subsets: ["latin"],
+  variable: "--font-bebas",
+})
 
 export const metadata: Metadata = {
   title: "Street Dreams: European Journey",


### PR DESCRIPTION
## Summary
- specify weight `400` for `Bebas Neue` in `RootLayout`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac3fe10a4832598d457f9e4b597d5