### PR TITLE
Fix missing font weight

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,11 @@ import "./globals.css"
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" })
 const orbitron = Orbitron({ subsets: ["latin"], variable: "--font-orbitron" })
-const russo = Russo_One({ subsets: ["latin"], variable: "--font-russo" })
+const russo = Russo_One({
+  weight: "400",
+  subsets: ["latin"],
+  variable: "--font-russo",
+})
 const bebas = Bebas_Neue({
   weight: "400",
   subsets: ["latin"],


### PR DESCRIPTION
## Summary
- fix `Russo One` font configuration by specifying weight

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac5d177b88325867cb723c8003c72