### PR TITLE
Fix state updates during render

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1155,6 +1155,7 @@ export default function StreetDreamsSoccer() {
     setDayEvents([])
 
     const interval = setInterval(() => {
+      let activityName: string | null = null
       setGameState((prevState) => {
         const newState = { ...prevState }
         const currentDay = newState.currentDay
@@ -1162,7 +1163,7 @@ export default function StreetDreamsSoccer() {
         const activity = activities.find((a) => a.id === activityId)
 
         if (activity) {
-          setCurrentActivity(activity.name)
+          activityName = activity.name
 
           // 에너지 체크
           if (activity.energyCost && newState.energy < activity.energyCost) {
@@ -1309,6 +1310,10 @@ export default function StreetDreamsSoccer() {
 
         return newState
       })
+
+      if (activityName) {
+        setCurrentActivity(activityName)
+      }
     }, 150)
 
     return () => clearInterval(interval)

--- a/components/growth-analysis.tsx
+++ b/components/growth-analysis.tsx
@@ -46,7 +46,7 @@ interface GrowthAnalysisProps {
   }[]
 }
 
-export function GrowthAnalysis({
+export default function GrowthAnalysis({
   growthData,
   playerAge,
   playerLevel,
@@ -479,3 +479,5 @@ export function GrowthAnalysis({
     </Card>
   )
 }
+
+export { GrowthAnalysis }


### PR DESCRIPTION
## Summary
- fix state update error by separating `setCurrentActivity` from game state updater
- export `GrowthAnalysis` as default for proper dynamic import

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684adb02437483259609e45e6b7a85a3