### PR TITLE
Add logos to scoreboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ The app now ships with a darker FIFA-inspired palette and Google Fonts:
 - **Inter** as the default body font
 
 Player cards can use the classes `fifa-card-gold`, `fifa-card-diamond`, or `fifa-card-legend` for special backgrounds. Use the `bg-fifa-gradient` utility for the default dark gradient background.
+
+## Scoreboard Overlay
+
+Matches now display a FIFA style scoreboard after each match. Home and away logos sit over a stadium backdrop thanks to open source imagery, giving it a proper game-day vibe. Dismiss the overlay with the **확인** button.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -64,6 +64,7 @@ import { GameMenu } from "@/components/ui/game-menu"
 import { NotificationSystem, type Notification } from "@/components/ui/notification-system"
 import { GameHud } from "@/components/ui/game-hud"
 import { MatchSystem } from "@/components/match-system"
+import { ScoreboardOverlay } from "@/components/ui/scoreboard-overlay"
 
 // 지역 및 학교 데이터
 const REGIONS = {
@@ -631,6 +632,8 @@ export default function StreetDreamsSoccer() {
   const setDayEvents = useGameUIStore((s) => s.setDayEvents)
   const selectedTemplate = useGameUIStore((s) => s.selectedTemplate)
   const setSelectedTemplate = useGameUIStore((s) => s.setSelectedTemplate)
+  const scoreboardResult = useGameUIStore((s) => s.scoreboardResult)
+  const setScoreboardResult = useGameUIStore((s) => s.setScoreboardResult)
 
   // 활동 목록 (기존과 동일)
   const activities: Activity[] = [
@@ -1109,10 +1112,18 @@ export default function StreetDreamsSoccer() {
           <Trophy className="w-4 h-4" />,
         )
 
+        setScoreboardResult({
+          opponent: newState.upcomingMatches[idx].opponent,
+          score: result.score,
+          result: result.result,
+          homeLogo: "/placeholder-logo.png",
+          opponentLogo: "/placeholder-logo.png",
+        })
+
         return newState
       })
     },
-    [addNotification],
+    [addNotification, setScoreboardResult],
   )
 
   // 주간 템플릿 적용
@@ -1498,6 +1509,8 @@ export default function StreetDreamsSoccer() {
       <GameMenu onSave={handleSave} onLoad={handleLoad} onReset={handleReset} onExit={handleExit} />
 
       <NotificationSystem notifications={notifications} onRemove={removeNotification} />
+
+      <ScoreboardOverlay data={scoreboardResult} onClose={() => setScoreboardResult(null)} />
 
       <div className="max-w-7xl mx-auto relative z-10 pt-20">
         {/* 월간 결과 모달 */}

--- a/components/ui/scoreboard-overlay.tsx
+++ b/components/ui/scoreboard-overlay.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import Image from "next/image"
+import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+export interface MatchResultDisplay {
+  opponent: string
+  score: string
+  result: "win" | "loss" | "draw"
+  opponentLogo?: string
+  homeLogo?: string
+}
+
+interface ScoreboardOverlayProps {
+  data: MatchResultDisplay | null
+  onClose: () => void
+}
+
+export function ScoreboardOverlay({ data, onClose }: ScoreboardOverlayProps) {
+  if (!data) return null
+
+  const resultText =
+    data.result === "win" ? "승리!" : data.result === "loss" ? "패배..." : "무승부"
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
+      <Card className="relative w-full max-w-md overflow-hidden text-white border-2 border-yellow-500 bg-fifa-gradient animate-slide-in-right">
+        <Image
+          src="https://images.unsplash.com/photo-1517927033932-b3d18e61fb3a?auto=format&fit=crop&w=800&q=60"
+          alt="scoreboard background"
+          fill
+          className="object-cover opacity-30"
+        />
+        <CardHeader className="relative z-10">
+          <CardTitle className="text-center text-4xl font-orbitron">
+            {data.score}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="relative z-10 space-y-4">
+          <div className="flex items-center justify-center gap-4">
+            <Image
+              src={data.homeLogo ?? "/placeholder-logo.png"}
+              alt="Street Dreams"
+              width={40}
+              height={40}
+            />
+            <div className="text-2xl font-bold">{resultText}</div>
+            <Image
+              src={data.opponentLogo ?? "/placeholder-logo.png"}
+              alt={data.opponent}
+              width={40}
+              height={40}
+            />
+          </div>
+          <div className="text-center text-xl">
+            Street Dreams <span className="text-yellow-400">vs</span> {data.opponent}
+          </div>
+          <Button onClick={onClose} className="w-full bg-primary text-primary-foreground">
+            확인
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -10,6 +10,13 @@ interface GameUIStore {
   currentActivity: string | null
   dayEvents: React.ReactNode[]
   selectedTemplate: string
+  scoreboardResult: {
+    opponent: string
+    score: string
+    result: 'win' | 'loss' | 'draw'
+    homeLogo?: string
+    opponentLogo?: string
+  } | null
   addNotification: (n: Notification) => void
   removeNotification: (id: string) => void
   setActiveTab: (tab: string) => void
@@ -22,6 +29,15 @@ interface GameUIStore {
       | ((prev: React.ReactNode[]) => React.ReactNode[]),
   ) => void
   setSelectedTemplate: (template: string) => void
+  setScoreboardResult: (
+    result: {
+      opponent: string
+      score: string
+      result: 'win' | 'loss' | 'draw'
+      homeLogo?: string
+      opponentLogo?: string
+    } | null,
+  ) => void
 }
 
 export const useGameUIStore = create<GameUIStore>((set) => ({
@@ -32,6 +48,7 @@ export const useGameUIStore = create<GameUIStore>((set) => ({
   currentActivity: null,
   dayEvents: [],
   selectedTemplate: "street_warrior",
+  scoreboardResult: null,
   addNotification: (n) => set((s) => ({ notifications: [...s.notifications, n] })),
   removeNotification: (id) =>
     set((s) => ({ notifications: s.notifications.filter((n) => n.id !== id) })),
@@ -45,4 +62,5 @@ export const useGameUIStore = create<GameUIStore>((set) => ({
         typeof events === "function" ? events(s.dayEvents) : events,
     })),
   setSelectedTemplate: (template) => set({ selectedTemplate: template }),
+  setScoreboardResult: (result) => set({ scoreboardResult: result }),
 }))


### PR DESCRIPTION
## Summary
- show opponent and home logos in the FIFA-style scoreboard overlay
- track logo paths in the UI store
- display placeholder logos after matches
- clarify README about the new imagery

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684adf8c584c8325b4c26698dcea7cfc