### PR TITLE
Configure Next.js image domains

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,7 +7,7 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
-    unoptimized: true,
+    domains: ["images.unsplash.com"],
   },
 }
 


### PR DESCRIPTION
## Summary
- configure Next.js `images` option so remote images from Unsplash work

## Testing
- `pnpm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5e7ee888325a68500598b5a9808