### PR TITLE
Lower toast timeout

### DIFF
--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string
@@ -181,8 +181,10 @@ function useToast() {
       if (index > -1) {
         listeners.splice(index, 1)
       }
+      toastTimeouts.forEach((timeout) => clearTimeout(timeout))
+      toastTimeouts.clear()
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string
@@ -181,8 +181,10 @@ function useToast() {
       if (index > -1) {
         listeners.splice(index, 1)
       }
+      toastTimeouts.forEach((timeout) => clearTimeout(timeout))
+      toastTimeouts.clear()
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- tweak TOAST_REMOVE_DELAY to 5000ms
- clear toast timeouts on unmount

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5e8274083258bc2a38830af4f9a