### PR TITLE
Add career collection feature

### DIFF
--- a/app/game/useGameState.ts
+++ b/app/game/useGameState.ts
@@ -63,6 +63,7 @@ const defaultState: GameState = {
   trophies: [],
   achievements: [],
   records: [],
+  careerCollection: [],
   memories: [],
   growthHistory: [],
   weeklyTemplate: WEEKLY_TEMPLATES.street_warrior.schedule,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -68,6 +68,7 @@ import type { GameState, Activity } from "@/lib/game/types"
 import { REGIONS, WEEKLY_TEMPLATES, getEnergyColor, getMoodIcon, getRarityColor } from "@/lib/game/helpers"
 import { MatchSystem } from "@/components/match-system"
 import { ScoreboardOverlay } from "@/components/ui/scoreboard-overlay"
+import { CareerCollection } from "@/components/career-collection"
 
 
 
@@ -173,6 +174,20 @@ export default function StreetDreamsSoccer() {
       },
     ],
     records: [],
+    careerCollection: [
+      {
+        id: "youth_join",
+        name: "유소년 팀 합류",
+        description: "동네 유소년 팀에 입단했다",
+        obtained: true,
+      },
+      {
+        id: "elite_school",
+        name: "축구 명문고 합격",
+        description: "명문 고등학교 축구부에 합격했다",
+        obtained: false,
+      },
+    ],
 
     memories: ["첫 축구공을 받은 날", "홍대 골목구장에서의 첫 경기"],
     growthHistory: [
@@ -1753,14 +1768,7 @@ export default function StreetDreamsSoccer() {
           </TabsContent>
 
           <TabsContent value="career" className="space-y-6">
-            <Card className="bg-gradient-to-br from-purple-600 to-pink-600 text-white border-2 border-purple-400">
-              <CardHeader>
-                <CardTitle>진로 시스템</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p>진로 시스템이 곧 추가됩니다!</p>
-              </CardContent>
-            </Card>
+            <CareerCollection items={gameState.careerCollection} />
           </TabsContent>
 
           <TabsContent value="collection" className="space-y-6">

--- a/components/career-collection.tsx
+++ b/components/career-collection.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { GraduationCap } from "lucide-react"
+import type { CareerCollectionItem } from "@/lib/game/types"
+
+interface CareerCollectionProps {
+  items: CareerCollectionItem[]
+}
+
+export function CareerCollection({ items }: CareerCollectionProps) {
+  return (
+    <Card className="bg-gradient-to-br from-purple-600 to-pink-600 text-white border-2 border-purple-400">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <GraduationCap className="w-5 h-5" /> 진로 컬렉션
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {items.length > 0 ? (
+          <ul className="list-disc pl-5 space-y-1 text-sm">
+            {items.map((item) => (
+              <li key={item.id} className={item.obtained ? "text-yellow-300" : "text-gray-400"}>
+                {item.name} - {item.description}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="text-center text-gray-300">아직 획득한 진로 컬렉션이 없습니다.</div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/game/types.ts
+++ b/lib/game/types.ts
@@ -85,6 +85,13 @@ export interface Record {
   value: number
 }
 
+export interface CareerCollectionItem {
+  id: string
+  name: string
+  description: string
+  obtained: boolean
+}
+
 export interface Match {
   id: string
   opponent: string
@@ -185,6 +192,7 @@ export interface GameState {
   trophies: TrophyType[]
   achievements: Achievement[]
   records: Record[]
+  careerCollection: CareerCollectionItem[]
 
   memories: string[]
   growthHistory: GrowthData[]


### PR DESCRIPTION
## Summary
- add `CareerCollectionItem` type and extend `GameState`
- create `CareerCollection` component to display the player's progress
- store example items in the default game state
- show career collection in the Career tab

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b004c55ac8325ba2962d704a2a8e7