### PR TITLE
Add skeletons for rival avatars

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import Image from "next/image"
+import { ImageWithSkeleton as Image } from "@/components/ui/image-with-skeleton"
 import Link from "next/link"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import Image from "next/image"
+import { ImageWithSkeleton as Image } from "@/components/ui/image-with-skeleton"
 import Link from "next/link"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"

--- a/components/rival-system.tsx
+++ b/components/rival-system.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { ImageWithSkeleton as Image } from "@/components/ui/image-with-skeleton"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -131,9 +132,11 @@ export function RivalSystem({ playerStats, rivals, onChallengeRival }: RivalSyst
               <div className="flex items-center justify-between mb-3">
                 <div className="flex items-center gap-3">
                   {rival.image ? (
-                    <img
+                    <Image
                       src={rival.image || "/placeholder.svg"}
                       alt={rival.name}
+                      width={48}
+                      height={48}
                       className="w-12 h-12 rounded-full object-cover border border-primary"
                     />
                   ) : (

--- a/components/ui/image-with-skeleton.tsx
+++ b/components/ui/image-with-skeleton.tsx
@@ -1,0 +1,20 @@
+import React, { useState } from "react"
+import Image, { ImageProps } from "next/image"
+import { cn } from "@/lib/utils"
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function ImageWithSkeleton({ className, ...props }: ImageProps) {
+  const [loaded, setLoaded] = useState(false)
+
+  return (
+    <div className={cn("relative", className)}>
+      {!loaded && <Skeleton className="absolute inset-0" />}
+      <Image
+        {...props}
+        className={cn(!loaded && "invisible", props.className)}
+        onLoad={() => setLoaded(true)}
+        onError={() => setLoaded(true)}
+      />
+    </div>
+  )
+}

--- a/components/ui/scoreboard-overlay.tsx
+++ b/components/ui/scoreboard-overlay.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import Image from "next/image"
+import { ImageWithSkeleton as Image } from "@/components/ui/image-with-skeleton"
 import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 


### PR DESCRIPTION
## Summary
- use `ImageWithSkeleton` for all image imports
- show skeletons for rival avatars

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b07020a388325928e2380b85fa003