### PR TITLE
Fix Phaser import

### DIFF
--- a/components/phaser-demo.tsx
+++ b/components/phaser-demo.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useRef } from "react"
-import Phaser from "phaser"
+import * as Phaser from "phaser"
 
 export default function PhaserDemo() {
   const containerRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
## Summary
- adjust Phaser import syntax for Next.js

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b0cf46d908325b25c93280ce5cd05