### PR TITLE
Fix duplicate key warning in notifications

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -554,7 +554,7 @@ export default function StreetDreamsSoccer() {
       icon?: React.ReactNode,
     ) => {
       const newNotification: Notification = {
-        id: Date.now().toString(),
+        id: crypto.randomUUID(),
         message,
         type,
         icon,


### PR DESCRIPTION
## Summary
- generate notification IDs using `crypto.randomUUID()`

## Testing
- `pnpm lint` *(fails: ESLint configuration prompts)*

------
https://chatgpt.com/codex/tasks/task_e_684b6f9226b083259ff9256b7f962ad7