### PR TITLE
Implement Firebase auth features

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=YOUR_MEASUREMENT_ID
 
 ## Firebase Client
 
-The Firebase client is initialized in [`lib/firebase.ts`](lib/firebase.ts) and exports the Firestore instance and Analytics (when supported).
+The Firebase client is initialized in [`lib/firebase.ts`](lib/firebase.ts) and
+exports the Firestore instance, Authentication and Analytics (when supported).
+Enable **Email/Password** authentication in the Firebase console and make sure
+the environment variables listed above are set in `.env.local`.
+
+The `/login` and `/signup` pages use `signInWithEmailAndPassword` and
+`createUserWithEmailAndPassword` with the exported `auth` instance.
 
 ## Phaser Mini Game
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,12 +2,29 @@
 
 import { ImageWithSkeleton as Image } from "@/components/ui/image-with-skeleton"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import { signInWithEmailAndPassword } from "firebase/auth"
+import { auth } from "@/lib/firebase"
 import logoSrc from "@/public/placeholder-logo.png"
 
 export default function LoginPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+
+  const handleLogin = async () => {
+    try {
+      await signInWithEmailAndPassword(auth, email, password)
+      router.push("/")
+    } catch (err: any) {
+      alert(err.message)
+    }
+  }
+
   return (
     <div className="relative flex min-h-screen items-center justify-center bg-black text-white">
       <Image
@@ -22,9 +39,25 @@ export default function LoginPage() {
           <CardTitle className="text-center font-bebas text-4xl">로그인</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <Input type="email" placeholder="이메일" />
-          <Input type="password" placeholder="비밀번호" />
-          <Button variant="game" className="w-full hover-lift">입장하기</Button>
+          <Input
+            type="email"
+            placeholder="이메일"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Input
+            type="password"
+            placeholder="비밀번호"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button
+            variant="game"
+            className="w-full hover-lift"
+            onClick={handleLogin}
+          >
+            입장하기
+          </Button>
           <Button asChild variant="secondary" className="w-full">
             <Link href="/">게스트 입장</Link>
           </Button>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -2,12 +2,34 @@
 
 import { ImageWithSkeleton as Image } from "@/components/ui/image-with-skeleton"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import { createUserWithEmailAndPassword } from "firebase/auth"
+import { auth } from "@/lib/firebase"
 import logoSrc from "@/public/placeholder-logo.png"
 
 export default function SignupPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [confirm, setConfirm] = useState("")
+
+  const handleSignup = async () => {
+    if (password !== confirm) {
+      alert("비밀번호가 일치하지 않습니다")
+      return
+    }
+    try {
+      await createUserWithEmailAndPassword(auth, email, password)
+      router.push("/login")
+    } catch (err: any) {
+      alert(err.message)
+    }
+  }
+
   return (
     <div className="relative flex min-h-screen items-center justify-center bg-black text-white">
       <Image
@@ -22,10 +44,30 @@ export default function SignupPage() {
           <CardTitle className="text-center font-bebas text-4xl">회원가입</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <Input type="email" placeholder="이메일" />
-          <Input type="password" placeholder="비밀번호" />
-          <Input type="password" placeholder="비밀번호 확인" />
-          <Button className="w-full bg-primary text-primary-foreground">가입하기</Button>
+          <Input
+            type="email"
+            placeholder="이메일"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Input
+            type="password"
+            placeholder="비밀번호"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Input
+            type="password"
+            placeholder="비밀번호 확인"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+          />
+          <Button
+            className="w-full bg-primary text-primary-foreground"
+            onClick={handleSignup}
+          >
+            가입하기
+          </Button>
           <p className="text-center text-sm">
             이미 계정이 있으신가요? {" "}
             <Link href="/login" className="text-primary underline">로그인</Link>

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from 'firebase/app'
 import { getAnalytics, isSupported } from 'firebase/analytics'
 import { getFirestore } from 'firebase/firestore'
+import { getAuth } from 'firebase/auth'
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -13,6 +14,8 @@ const firebaseConfig = {
 }
 
 const app = initializeApp(firebaseConfig)
+
+export const auth = getAuth(app)
 
 let analytics: ReturnType<typeof getAnalytics> | undefined
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- expose Firebase auth instance
- connect Login page with `signInWithEmailAndPassword`
- connect Signup page with `createUserWithEmailAndPassword`
- document enabling Firebase auth in README
- fix duplicate export in Firebase client module

## Testing
- `pnpm build` *(fails: invalid API key)*
- `pnpm lint` *(fails: Next.js ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_684d1711a77c8325a8c588895d2aa183